### PR TITLE
remove confusing prompt model property

### DIFF
--- a/docs_qa/rag_manual_stuff.py
+++ b/docs_qa/rag_manual_stuff.py
@@ -34,9 +34,7 @@ class RagPromptReply(BaseModel):
     """Relevant context data"""
     helpful_answer: str = Field(..., description="The helpful answer")
     i_dont_know: bool = Field(..., description="True when unable to answer based on the given context.")
-    relevant_contexts: Sequence[RagContextRefs] = Field(..., description="List of context documents that were relevant when answering the question.")
-    translated_answer: str = Field(..., description="The translated answer")
-
+    relevant_contexts: Sequence[RagContextRefs] = Field(..., description="List of context documents that were relevant when answering the question.")    
 
 
 async def rag_with_typesense(user_input):


### PR DESCRIPTION
The recent increase in model validation errors seems to be due to this left over property that I missed when converting this prompt to use a discrete translation stage.